### PR TITLE
Use gl3w for linux

### DIFF
--- a/imgui/src/extension_imgui.cpp
+++ b/imgui/src/extension_imgui.cpp
@@ -5,7 +5,8 @@
 
 #include <stdlib.h>
 
-#if defined(DM_PLATFORM_WINDOWS)
+#include "imgui/imconfig.h"
+#if defined(IMGUI_IMPL_OPENGL_LOADER_GL3W)
 #include <GL/gl3w.h>
 #endif
 
@@ -600,7 +601,7 @@ static dmExtension::Result imgui_Draw(dmExtension::Params* params)
 
 static void imgui_Init(float width, float height)
 {
-#if defined(DM_PLATFORM_WINDOWS)
+#if defined(IMGUI_IMPL_OPENGL_LOADER_GL3W)
     int r = gl3wInit();
     if (r != GL3W_OK) {
         dmLogError("Failed to initialize OpenGL: %d", r);

--- a/imgui/src/gl3w/gl3w.c
+++ b/imgui/src/gl3w/gl3w.c
@@ -26,7 +26,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#if defined(DM_PLATFORM_WINDOWS)
+#if defined(DM_PLATFORM_WINDOWS) || defined(DM_PLATFORM_LINUX)
 
 #include <GL/gl3w.h>
 #include <stdlib.h>

--- a/imgui/src/imgui/imconfig.h
+++ b/imgui/src/imgui/imconfig.h
@@ -3,6 +3,8 @@
 #undef GL_ES_VERSION_2_0
 #elif defined(DM_PLATFORM_WINDOWS)
 #define IMGUI_IMPL_OPENGL_LOADER_GL3W
+#elif defined(DM_PLATFORM_LINUX)
+#define IMGUI_IMPL_OPENGL_LOADER_GL3W
 #else
 #define IMGUI_IMPL_OPENGL_LOADER_CUSTOM "dummy_loader.h"
 #endif


### PR DESCRIPTION
As far as I understand the gl3w code added for Windows also support linux and macOS. This small changes make example run on linux.
(There was https://github.com/britzl/extension-imgui/pull/1, but it seems no longer work, because current state of repo doesnt compile on linux)