### PR TITLE
Disable stb_image's SIMD support for Windows

### DIFF
--- a/imgui/ext.manifest
+++ b/imgui/ext.manifest
@@ -1,1 +1,10 @@
 name: "DefoldImGui"
+
+platforms:
+    x86-win32:
+        context:
+            defines: ["STBI_NO_SIMD"]
+
+    x86_64-win32:
+        context:
+            defines: ["STBI_NO_SIMD"]


### PR DESCRIPTION
As a temporary workaround for the https://github.com/britzl/extension-imgui/issues/14 issue.

The extension builds well on the Windows platform again.
