### PR TITLE
Don't use a static variable in ColorEdit4

### DIFF
--- a/example/tab2.lua
+++ b/example/tab2.lua
@@ -2,6 +2,7 @@ local JEDI = { "Luke", "Obi-Wan", "Yoda" }
 local SITH = { "Maul", "Vader", "Palpatine" }
 
 local COLOR = vmath.vector4()
+local COLOR2 = vmath.vector4(255, 0, 0, 1)
 
 return function(self)
 	local selected = imgui.tree_node("root")
@@ -77,4 +78,5 @@ return function(self)
 
 	self.color = self.color or vmath.vector4()
 	imgui.color_edit4("coloredit4", self.color)
+	imgui.color_edit4("other color", COLOR2)
 end

--- a/imgui/src/extension_imgui.cpp
+++ b/imgui/src/extension_imgui.cpp
@@ -1722,7 +1722,7 @@ static int imgui_ColorEdit4(lua_State* L)
         flags = luaL_checknumber(L, 3);
     }
 
-    static ImVec4 c(color->getX(), color->getY(), color->getZ(), color->getW());
+    ImVec4 c(color->getX(), color->getY(), color->getZ(), color->getW());
     ImGui::ColorEdit4(label, (float*)&c, flags);
     color->setX(c.x);
     color->setY(c.y);


### PR DESCRIPTION
The use of a static color variable in the ColorEdit4 function causes a bug when the function is called multiple times. The different invocations share state, and different color editors modify / interfere with each other. And even in the case where the function is called only once, the color editor may incorrectly remember old state if there are other widgets working with the same state. Making the color non-static fixes this.

(I've tested and verified this in my own project. To reproduce, create 2 different color editors and pass each one a different color vector; they'll both show the same color, and manipulating one of them will change the state of the other. I've added a commit to this PR that should demonstrate this issue in the example.)