### PR TITLE
Add bindings for PushStyleVar and PopStyleVar

### DIFF
--- a/api.json
+++ b/api.json
@@ -1906,10 +1906,17 @@
                         },
                         {
                             "description": "",
-                            "has_params": false,
+                            "has_params": true,
                             "has_returns": false,
                             "name": "pop_style_var",
-                            "params": [],
+                            "params": [
+                                {
+                                    "description": "Optional number specifying how many style vars to pop; defaults to 1",
+                                    "name": "count",
+                                    "type": null
+                                }
+                            ],
+                            "params_string": "count",
                             "returns": [],
                             "summary": "PopStyleVar",
                             "usage": null

--- a/api.json
+++ b/api.json
@@ -1911,9 +1911,9 @@
                             "name": "pop_style_var",
                             "params": [
                                 {
-                                    "description": "Optional number specifying how many style vars to pop; defaults to 1",
+                                    "description": "Number of style vars to pop; optional, defaults to 1",
                                     "name": "count",
-                                    "type": null
+                                    "type": "number"
                                 }
                             ],
                             "params_string": "count",

--- a/api.json
+++ b/api.json
@@ -1884,6 +1884,38 @@
                         },
                         {
                             "description": "",
+                            "has_params": true,
+                            "has_returns": false,
+                            "name": "push_style_var",
+                            "params": [
+                                {
+                                    "description": "Enum for the style to be pushed",
+                                    "name": "style_var",
+                                    "type": "number"
+                                },
+                                {
+                                    "description": "Number or vmath.vector3 specifying the value of the style var",
+                                    "name": "value",
+                                    "type": null
+                                }
+                            ],
+                            "params_string": "style_var,value",
+                            "returns": [],
+                            "summary": "PushStyleVar",
+                            "usage": null
+                        },
+                        {
+                            "description": "",
+                            "has_params": false,
+                            "has_returns": false,
+                            "name": "pop_style_var",
+                            "params": [],
+                            "returns": [],
+                            "summary": "PopStyleVar",
+                            "usage": null
+                        },
+                        {
+                            "description": "",
                             "has_params": false,
                             "has_returns": false,
                             "name": "set_window_font_scale",

--- a/api.md
+++ b/api.md
@@ -842,7 +842,7 @@ PopStyleVar
 
 
 PARAMS
-* `count` - Optional number specifying how many style vars to pop; defaults to 1
+* `count` [`number`] - Number of style vars to pop; optional, defaults to 1
 
 
 ### set_window_font_scale()

--- a/api.md
+++ b/api.md
@@ -828,6 +828,20 @@ PopStyleColor
 
 
 
+### push_style_var(style_var,value)
+PushStyleVar 
+
+
+PARAMS
+* `style_var` [`number`] - Enum for the style to be pushed
+* `value` - Number or vmath.vector3 specifying the value of the style var
+
+
+### pop_style_var()
+PopStyleVar 
+
+
+
 ### set_window_font_scale()
 SetWindowFontScale 
 

--- a/api.md
+++ b/api.md
@@ -837,9 +837,12 @@ PARAMS
 * `value` - Number or vmath.vector3 specifying the value of the style var
 
 
-### pop_style_var()
+### pop_style_var(count)
 PopStyleVar 
 
+
+PARAMS
+* `count` - Optional number specifying how many style vars to pop; defaults to 1
 
 
 ### set_window_font_scale()

--- a/example/tab1.lua
+++ b/example/tab1.lua
@@ -21,17 +21,23 @@ return function(self)
 
 	imgui.separator()
 
+	imgui.push_style_var(imgui.STYLEVAR_FRAMEPADDING, vmath.vector3(0, 0, 0))
 	if imgui.button("Reset Counter") then
 		self.counter = 0
 	end
 	imgui.same_line()
+	imgui.push_style_var(imgui.STYLEVAR_FRAMEPADDING, vmath.vector3(5, 5, 0))
+	imgui.push_style_var(imgui.STYLEVAR_FRAMEROUNDING, 10)
 	if imgui.button_arrow("Up", imgui.DIR_UP) then
 		self.counter = self.counter + 1
 	end
+	imgui.pop_style_var()
 	imgui.same_line()
+	imgui.push_style_var(imgui.STYLEVAR_FRAMEPADDING, vmath.vector3(10, 10, 5))
 	if imgui.button_arrow("Down", imgui.DIR_DOWN) then
 		self.counter = self.counter - 1
 	end
+	imgui.pop_style_var(3)
 	imgui.same_line()
 	imgui.text(("counter = %d"):format(self.counter))
 

--- a/imgui/api/imgui.script_api
+++ b/imgui/api/imgui.script_api
@@ -920,6 +920,10 @@
   - name: pop_style_var
     type: function
     desc: PopStyleVar 
+    parameters:
+    - name: count
+      type: None
+      desc: Optional number specifying how many style vars to pop; defaults to 1
 
   - name: set_window_font_scale
     type: function

--- a/imgui/api/imgui.script_api
+++ b/imgui/api/imgui.script_api
@@ -922,8 +922,8 @@
     desc: PopStyleVar 
     parameters:
     - name: count
-      type: None
-      desc: Optional number specifying how many style vars to pop; defaults to 1
+      type: number
+      desc: Number of style vars to pop; optional, defaults to 1
 
   - name: set_window_font_scale
     type: function

--- a/imgui/api/imgui.script_api
+++ b/imgui/api/imgui.script_api
@@ -906,6 +906,21 @@
     type: function
     desc: PopStyleColor 
 
+  - name: push_style_var
+    type: function
+    desc: PushStyleVar 
+    parameters:
+    - name: style_var
+      type: number
+      desc: Enum for the style to be pushed
+    - name: value
+      type: None
+      desc: Number or vmath.vector3 specifying the value of the style var
+
+  - name: pop_style_var
+    type: function
+    desc: PopStyleVar 
+
   - name: set_window_font_scale
     type: function
     desc: SetWindowFontScale 

--- a/imgui/src/extension_imgui.cpp
+++ b/imgui/src/extension_imgui.cpp
@@ -2760,7 +2760,7 @@ static int imgui_PushStyleVar(lua_State *L)
 
 /** PopStyleVar
  * @name pop_style_var
- * @param count optional number specifying how many style vars to pop; defaults to 1
+ * @number count number of style vars to pop; optional, defaults to 1
  */
 static int imgui_PopStyleVar(lua_State *L)
 {

--- a/imgui/src/extension_imgui.cpp
+++ b/imgui/src/extension_imgui.cpp
@@ -2700,6 +2700,79 @@ static int imgui_PopStyleColor(lua_State* L)
     return 0;
 }
 
+/** PushStyleVar
+ * @name push_style_var
+ * @tparam number style_var enum for the style to be pushed
+ * @param value number or vmath.vector3 specifying the value of the style var
+ */
+static int imgui_PushStyleVar(lua_State *L)
+{
+    DM_LUA_STACK_CHECK(L, 0);
+    uint32_t style_var = luaL_checkint(L, 1);
+    switch(style_var)
+    {
+        case ImGuiStyleVar_Alpha:
+        case ImGuiStyleVar_DisabledAlpha:
+        case ImGuiStyleVar_WindowRounding:
+        case ImGuiStyleVar_WindowBorderSize:
+        case ImGuiStyleVar_ChildRounding:
+        case ImGuiStyleVar_ChildBorderSize:
+        case ImGuiStyleVar_PopupRounding:
+        case ImGuiStyleVar_PopupBorderSize:
+        case ImGuiStyleVar_FrameRounding:
+        case ImGuiStyleVar_FrameBorderSize:
+        case ImGuiStyleVar_IndentSpacing:
+        case ImGuiStyleVar_ScrollbarSize:
+        case ImGuiStyleVar_ScrollbarRounding:
+        case ImGuiStyleVar_GrabMinSize:
+        case ImGuiStyleVar_GrabRounding:
+        case ImGuiStyleVar_TabRounding:
+        case ImGuiStyleVar_TabBorderSize:
+        case ImGuiStyleVar_TabBarBorderSize:
+        case ImGuiStyleVar_TableAngledHeadersAngle:
+        case ImGuiStyleVar_SeparatorTextBorderSize:
+        {
+            float val_float = luaL_checknumber(L, 2);
+            ImGui::PushStyleVar(style_var, val_float);
+            break;
+        }
+        case ImGuiStyleVar_WindowPadding:
+        case ImGuiStyleVar_WindowMinSize:
+        case ImGuiStyleVar_WindowTitleAlign:
+        case ImGuiStyleVar_FramePadding:
+        case ImGuiStyleVar_ItemSpacing:
+        case ImGuiStyleVar_ItemInnerSpacing:
+        case ImGuiStyleVar_CellPadding:
+        case ImGuiStyleVar_TableAngledHeadersTextAlign:
+        case ImGuiStyleVar_ButtonTextAlign:
+        case ImGuiStyleVar_SelectableTextAlign:
+        case ImGuiStyleVar_SeparatorTextAlign:
+        case ImGuiStyleVar_SeparatorTextPadding:
+        {
+            dmVMath::Vector3* val_vec3 = dmScript::CheckVector3(L, 2);
+            ImVec2 val_vec2(val_vec3->getX(), val_vec3->getY());
+            ImGui::PushStyleVar(style_var, val_vec2);
+            break;
+        }
+    }
+    return 0;
+}
+
+/** PopStyleVar
+ * @name pop_style_var
+ */
+static int imgui_PopStyleVar(lua_State *L)
+{
+    DM_LUA_STACK_CHECK(L, 0);
+    int count = 1;
+    if (lua_isnumber(L, 1))
+    {
+        count = luaL_checkint(L, 1);
+    }
+    ImGui::PopStyleVar(count);
+    return 0;
+}
+
 /** SetWindowFontScale
  * @name set_window_font_scale
  */
@@ -3393,6 +3466,9 @@ static const luaL_reg Module_methods[] =
     {"push_style_color", imgui_PushStyleColor},
     {"pop_style_color", imgui_PopStyleColor},
 
+    {"push_style_var", imgui_PushStyleVar},
+    {"pop_style_var", imgui_PopStyleVar},
+
     {"push_item_width", imgui_PushItemWidth},
     {"pop_item_width", imgui_PopItemWidth},
     {"set_next_item_width", imgui_SetNextItemWidth},
@@ -3725,6 +3801,40 @@ static void LuaInit(lua_State* L)
     lua_setfieldstringint(L, "GLYPH_RANGES_CYRILLIC", ExtImGuiGlyphRanges_Cyrillic);               // Default + about 400 Cyrillic characters
     lua_setfieldstringint(L, "GLYPH_RANGES_THAI", ExtImGuiGlyphRanges_Thai);                   // Default + Thai characters
     lua_setfieldstringint(L, "GLYPH_RANGES_VIETNAMESE", ExtImGuiGlyphRanges_Vietnamese);             // Default + Vietnamese characters
+
+    // For use with push_style_var / Imgui::PushStyleVar
+    lua_setfieldstringint(L, "STYLEVAR_ALPHA", ImGuiStyleVar_Alpha);                                             // float  Alpha
+    lua_setfieldstringint(L, "STYLEVAR_DISABLEDALPHA", ImGuiStyleVar_DisabledAlpha);                             // float  DisabledAlpha
+    lua_setfieldstringint(L, "STYLEVAR_WINDOWPADDING", ImGuiStyleVar_WindowPadding);                             // ImVec2 WindowPadding
+    lua_setfieldstringint(L, "STYLEVAR_WINDOWROUNDING", ImGuiStyleVar_WindowRounding);                           // float  WindowRounding
+    lua_setfieldstringint(L, "STYLEVAR_WINDOWBORDERSIZE", ImGuiStyleVar_WindowBorderSize);                       // float  WindowBorderSize
+    lua_setfieldstringint(L, "STYLEVAR_WINDOWMINSIZE", ImGuiStyleVar_WindowMinSize);                             // ImVec2 WindowMinSize
+    lua_setfieldstringint(L, "STYLEVAR_WINDOWTITLEALIGN", ImGuiStyleVar_WindowTitleAlign);                       // ImVec2 WindowTitleAlign
+    lua_setfieldstringint(L, "STYLEVAR_CHILDROUNDING", ImGuiStyleVar_ChildRounding);                             // float  ChildRounding
+    lua_setfieldstringint(L, "STYLEVAR_CHILDBORDERSIZE", ImGuiStyleVar_ChildBorderSize);                         // float  ChildBorderSize
+    lua_setfieldstringint(L, "STYLEVAR_POPUPROUNDING", ImGuiStyleVar_PopupRounding);                             // float  PopupRounding
+    lua_setfieldstringint(L, "STYLEVAR_POPUPBORDERSIZE", ImGuiStyleVar_PopupBorderSize);                         // float  PopupBorderSize
+    lua_setfieldstringint(L, "STYLEVAR_FRAMEPADDING", ImGuiStyleVar_FramePadding);                               // ImVec2 FramePadding
+    lua_setfieldstringint(L, "STYLEVAR_FRAMEROUNDING", ImGuiStyleVar_FrameRounding);                             // float  FrameRounding
+    lua_setfieldstringint(L, "STYLEVAR_FRAMEBORDERSIZE", ImGuiStyleVar_FrameBorderSize);                         // float  FrameBorderSize
+    lua_setfieldstringint(L, "STYLEVAR_ITEMSPACING", ImGuiStyleVar_ItemSpacing);                                 // ImVec2 ItemSpacing
+    lua_setfieldstringint(L, "STYLEVAR_ITEMINNERSPACING", ImGuiStyleVar_ItemInnerSpacing);                       // ImVec2 ItemInnerSpacing
+    lua_setfieldstringint(L, "STYLEVAR_INDENTSPACING", ImGuiStyleVar_IndentSpacing);                             // float  IndentSpacing
+    lua_setfieldstringint(L, "STYLEVAR_CELLPADDING", ImGuiStyleVar_CellPadding);                                 // ImVec2 CellPadding
+    lua_setfieldstringint(L, "STYLEVAR_SCROLLBARSIZE", ImGuiStyleVar_ScrollbarSize);                             // float  ScrollbarSize
+    lua_setfieldstringint(L, "STYLEVAR_SCROLLBARROUNDING", ImGuiStyleVar_ScrollbarRounding);                     // float  ScrollbarRounding
+    lua_setfieldstringint(L, "STYLEVAR_GRABMINSIZE", ImGuiStyleVar_GrabMinSize);                                 // float  GrabMinSize
+    lua_setfieldstringint(L, "STYLEVAR_GRABROUNDING", ImGuiStyleVar_GrabRounding);                               // float  GrabRounding
+    lua_setfieldstringint(L, "STYLEVAR_TABROUNDING", ImGuiStyleVar_TabRounding);                                 // float  TabRounding
+    lua_setfieldstringint(L, "STYLEVAR_TABBORDERSIZE", ImGuiStyleVar_TabBorderSize);                             // float  TabBorderSize
+    lua_setfieldstringint(L, "STYLEVAR_TABBARBORDERSIZE", ImGuiStyleVar_TabBarBorderSize);                       // float  TabBarBorderSize
+    lua_setfieldstringint(L, "STYLEVAR_TABLEANGLEDHEADERSANGLE", ImGuiStyleVar_TableAngledHeadersAngle);         // float  TableAngledHeadersAngle
+    lua_setfieldstringint(L, "STYLEVAR_TABLEANGLEDHEADERSTEXTALIGN", ImGuiStyleVar_TableAngledHeadersTextAlign); // ImVec2 TableAngledHeadersTextAlign
+    lua_setfieldstringint(L, "STYLEVAR_BUTTONTEXTALIGN", ImGuiStyleVar_ButtonTextAlign);                         // ImVec2 ButtonTextAlign
+    lua_setfieldstringint(L, "STYLEVAR_SELECTABLETEXTALIGN", ImGuiStyleVar_SelectableTextAlign);                 // ImVec2 SelectableTextAlign
+    lua_setfieldstringint(L, "STYLEVAR_SEPARATORTEXTBORDERSIZE", ImGuiStyleVar_SeparatorTextBorderSize);         // float  SeparatorTextBorderSize
+    lua_setfieldstringint(L, "STYLEVAR_SEPARATORTEXTALIGN", ImGuiStyleVar_SeparatorTextAlign);                   // ImVec2 SeparatorTextAlign
+    lua_setfieldstringint(L, "STYLEVAR_SEPARATORTEXTPADDING", ImGuiStyleVar_SeparatorTextPadding);               // ImVec2 SeparatorTextPadding
 
     lua_pop(L, 1);
     assert(top == lua_gettop(L));

--- a/imgui/src/extension_imgui.cpp
+++ b/imgui/src/extension_imgui.cpp
@@ -2760,6 +2760,7 @@ static int imgui_PushStyleVar(lua_State *L)
 
 /** PopStyleVar
  * @name pop_style_var
+ * @param count optional number specifying how many style vars to pop; defaults to 1
  */
 static int imgui_PopStyleVar(lua_State *L)
 {


### PR DESCRIPTION
Would be useful to make local / one-off style changes.

Regarding the implementation, there was a choice between using the enums provided by ImGui, or using string constants and converting them into the enums internally. I chose the enums because the implementation is simpler, and reflects how the ImGui API does things. It will also allow for better annotations / autocomplete once those are available.

Also, regarding the docs, the second parameter is untyped because it can be either a number or vector, and there's currently no way of specifying unions.