### PR TITLE
Added small_button, is_window_appearing, get_font_size and added click status return to selectable

### DIFF
--- a/imgui/api/imgui.lua
+++ b/imgui/api/imgui.lua
@@ -912,6 +912,9 @@ function imgui.is_window_focused(flags) end
 ---@return boolean result
 function imgui.is_window_hovered() end
 
+---@return boolean result
+function imgui.is_window_appearing() end
+
 ---@return number x
 ---@return number y
 function imgui.get_content_region_avail() end
@@ -1206,6 +1209,7 @@ function imgui.color_edit4(label, color, flags) end
 ---@param selected boolean?
 ---@param flags? integer|imgui.SELECTABLE
 ---@return boolean selected
+---@return boolean pushed
 function imgui.selectable(text, selected, flags) end
 
 ---@param text string
@@ -1213,6 +1217,10 @@ function imgui.selectable(text, selected, flags) end
 ---@param height? integer
 ---@return boolean pushed
 function imgui.button(text, width, height) end
+
+---@param text string
+---@return boolean pushed
+function imgui.small_button(text) end
 
 ---@param texture_id number
 ---@param width? integer
@@ -1404,6 +1412,9 @@ function imgui.font_pop() end
 ---@param scale number
 ---@return number old_scale
 function imgui.font_scale(font_id, scale) end
+
+---@return number font_size
+function imgui.get_font_size() end
 
 ---@return number height
 function imgui.get_frame_height() end

--- a/imgui/api/imgui.script_api
+++ b/imgui/api/imgui.script_api
@@ -570,6 +570,14 @@
     - name: result
       type: bool
 
+  - name: is_window_appearing
+    type: function
+    desc: |
+      IsWindowAppearing.
+    returns:
+    - name: result
+      type: bool
+
   - name: get_content_region_avail
     type: function
     desc: |
@@ -1212,6 +1220,8 @@
     returns:
     - name: selected
       type: boolean
+    - name: pushed
+      type: boolean
 
   - name: button
     type: function
@@ -1226,6 +1236,17 @@
     - name: height
       type: number
       optional: True
+    returns:
+    - name: pushed
+      type: boolean
+
+  - name: small_button
+    type: function
+    desc: |
+      SmallButton.
+    parameters:
+    - name: text
+      type: string
     returns:
     - name: pushed
       type: boolean
@@ -1758,6 +1779,14 @@
       type: number
     returns:
     - name: old_scale
+      type: number
+
+  - name: get_font_size
+    type: function
+    desc: |
+      GetFontSize.
+    returns:
+    - name: font_size
       type: number
 
   - name: get_frame_height

--- a/imgui/src/extension_imgui.cpp
+++ b/imgui/src/extension_imgui.cpp
@@ -884,6 +884,19 @@ static int imgui_IsWindowHovered(lua_State* L)
     return 1;
 }
 
+/** IsWindowAppearing
+ * @name is_window_appearing
+ * @treturn bool result
+ */
+static int imgui_IsWindowAppearing(lua_State* L)
+{
+    DM_LUA_STACK_CHECK(L, 1);
+    imgui_NewFrame();
+    bool appearing = ImGui::IsWindowAppearing();
+    lua_pushboolean(L, appearing);
+    return 1;
+}
+
 /** GetContentRegionAvail
  * @name get_content_region_avail
  * @treturn number x
@@ -2066,7 +2079,7 @@ static int imgui_ColorEdit4(lua_State* L)
  */
 static int imgui_Selectable(lua_State* L)
 {
-    DM_LUA_STACK_CHECK(L, 1);
+    DM_LUA_STACK_CHECK(L, 2);
     imgui_NewFrame();
     const char* text = luaL_checkstring(L, 1);
     bool selected = lua_toboolean(L, 2);
@@ -2075,9 +2088,10 @@ static int imgui_Selectable(lua_State* L)
     {
         flags = luaL_checkint(L, 3);
     }
-    ImGui::Selectable(text, &selected, flags);
+    bool pushed = ImGui::Selectable(text, &selected, flags);
     lua_pushboolean(L, selected);
-    return 1;
+    lua_pushboolean(L, pushed);
+    return 2;
 }
 
 /** Button
@@ -2104,6 +2118,21 @@ static int imgui_Button(lua_State* L)
     {
         pushed = ImGui::Button(text);
     }
+    lua_pushboolean(L, pushed);
+    return 1;
+}
+
+/** SmallButton
+ * @name small_button
+ * @string text
+ * @treturn boolean pushed
+ */
+static int imgui_SmallButton(lua_State* L)
+{
+    DM_LUA_STACK_CHECK(L, 1);
+    imgui_NewFrame();
+    const char* text = luaL_checkstring(L, 1);
+    bool pushed = ImGui::SmallButton(text);
     lua_pushboolean(L, pushed);
     return 1;
 }
@@ -3514,6 +3543,17 @@ static int imgui_GetFrameHeight(lua_State* L)
     return 1;
 }
 
+/** GetFontSize
+ * @name get_font_size
+ * @treturn number font_size
+ */
+static int imgui_GetFontSize(lua_State* L)
+{
+    DM_LUA_STACK_CHECK(L, 1);
+    lua_pushnumber(L, ImGui::GetFontSize());
+    return 1;
+}
+
 
 // ----------------------------
 // ----- DRAW -----------------
@@ -3787,6 +3827,7 @@ static const luaL_reg Module_methods[] =
     {"font_push", imgui_FontPush},
     {"font_pop", imgui_FontPop},
     {"font_scale", imgui_FontScale},
+    {"get_font_size", imgui_GetFontSize},
 
     {"set_next_window_size", imgui_SetNextWindowSize},
     {"set_next_window_pos", imgui_SetNextWindowPos},
@@ -3797,6 +3838,7 @@ static const luaL_reg Module_methods[] =
     {"end_window", imgui_End},
     {"is_window_focused", imgui_IsWindowFocused},
     {"is_window_hovered", imgui_IsWindowHovered},
+    {"is_window_appearing", imgui_IsWindowAppearing},
     {"get_content_region_avail", imgui_GetContentRegionAvail},
     {"get_window_content_region_max", imgui_GetWindowContentRegionMax},
 
@@ -3864,6 +3906,7 @@ static const luaL_reg Module_methods[] =
     {"slider_float3", imgui_SliderFloat3},
     {"slider_float4", imgui_SliderFloat4},
     {"button", imgui_Button},
+    {"small_button", imgui_SmallButton},
     {"button_image", imgui_ButtonImage},
     {"button_arrow", imgui_ButtonArrow},
     {"checkbox", imgui_Checkbox},


### PR DESCRIPTION
  - Added `imgui.small_button()`, `imgui.is_window_appearing()`, `imgui.get_font_size()` bindings
  - `imgui.selectable()` now returns a second value `pushed` (click status). Ideally it would be the first return value, but to maintain backward compatibility with existing code that only reads `selected`, it is returned second.