### PR TITLE
Add draw callback hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,25 @@ The current state of platform support:
 Refer to [example/example.script](/example/example.script) to learn how to use the extension. Also check the bindings in `LuaInit()` in `extension_imgui.cpp`.
 
 
+## Native C/C++ draw callbacks
+Native extensions can register a draw callback invoked after `ImGui::NewFrame()` and before `ImGui::Render()`:
+
+```cpp
+#include "extension_imgui.h"
+#include "imgui/src/imgui/imgui.h"
+
+static void Draw(void* user_data) {
+    ImGui::Begin("Native Window");
+    ImGui::Text("Hello");
+    ImGui::End();
+}
+
+DefoldImGui_RegisterDrawCallback(Draw, 0);
+```
+
+Callbacks run on the render thread/post-render callback where extension-imgui renders. Do not call `ImGui::NewFrame()`, `ImGui::Render()`, or backend render functions from the callback.
+
+
 ### Input
 You need to update the input state in Dear ImGUI each frame to accurately reflect user input:
 

--- a/README.md
+++ b/README.md
@@ -29,25 +29,6 @@ The current state of platform support:
 Refer to [example/example.script](/example/example.script) to learn how to use the extension. Also check the bindings in `LuaInit()` in `extension_imgui.cpp`.
 
 
-## Native C/C++ draw callbacks
-Native extensions can register a draw callback invoked after `ImGui::NewFrame()` and before `ImGui::Render()`:
-
-```cpp
-#include "extension_imgui.h"
-#include "imgui/src/imgui/imgui.h"
-
-static void Draw(void* user_data) {
-    ImGui::Begin("Native Window");
-    ImGui::Text("Hello");
-    ImGui::End();
-}
-
-DefoldImGui_RegisterDrawCallback(Draw, 0);
-```
-
-Callbacks run on the render thread/post-render callback where extension-imgui renders. Do not call `ImGui::NewFrame()`, `ImGui::Render()`, or backend render functions from the callback.
-
-
 ### Input
 You need to update the input state in Dear ImGUI each frame to accurately reflect user input:
 
@@ -65,6 +46,23 @@ You can add the `imgui/imgui.script` to a game object and let that handle input 
 ### Display size
 You need to let Dear ImGUI know of any changes to the window size by calling `imgui.set_display_size(w, h)` when the screen size changes.
 
+### Native C/C++ draw callbacks
+Native extensions can register a draw callback invoked after `ImGui::NewFrame()` and before `ImGui::Render()`:
+
+```cpp
+#include "extension_imgui.h"
+#include "imgui/src/imgui/imgui.h"
+
+static void Draw(void* user_data) {
+    ImGui::Begin("Native Window");
+    ImGui::Text("Hello");
+    ImGui::End();
+}
+
+DefoldImGui_RegisterDrawCallback(Draw, 0);
+```
+
+Callbacks run on the render thread/post-render callback where extension-imgui renders. Do not call `ImGui::NewFrame()`, `ImGui::Render()`, or backend render functions from the callback.
 
 ### How to generate API docs
 

--- a/imgui/include/extension_imgui.h
+++ b/imgui/include/extension_imgui.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <stdint.h>
+#include <dmsdk/dlib/shared_library.h>
+
+#ifndef __cplusplus
+#include <stdbool.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void (*DefoldImGuiDrawCallback)(void* user_data);
+
+// Register a native draw callback. The callback is invoked once per rendered
+// ImGui frame after ImGui::NewFrame() and before ImGui::Render().
+// Returns true if registered, false if callback is null or the callback table is full.
+DM_DLLEXPORT bool DefoldImGui_RegisterDrawCallback(DefoldImGuiDrawCallback callback, void* user_data);
+
+// Remove a previously registered draw callback. Safe to call even if not registered.
+DM_DLLEXPORT void DefoldImGui_UnregisterDrawCallback(DefoldImGuiDrawCallback callback, void* user_data);
+
+#ifdef __cplusplus
+}
+#endif

--- a/imgui/src/extension_imgui.cpp
+++ b/imgui/src/extension_imgui.cpp
@@ -23,6 +23,8 @@
 
 #include <dmsdk/sdk.h>
 
+#include "extension_imgui.h"
+
 #if !defined(DM_HEADLESS)
 
 #define MODULE_NAME "imgui"
@@ -66,6 +68,82 @@ static dmArray<ImFont*> g_imgui_Fonts;
 static dmArray<ImgObject> g_imgui_Images;
 static bool g_VerifyGraphicsCalls   = false;
 static bool g_RenderingEnabled      = true;
+
+#define DEFOLD_IMGUI_MAX_DRAW_CALLBACKS 16
+
+struct DefoldImGuiDrawCallbackEntry
+{
+    DefoldImGuiDrawCallback m_Callback;
+    void*                   m_UserData;
+};
+
+static DefoldImGuiDrawCallbackEntry g_DrawCallbacks[DEFOLD_IMGUI_MAX_DRAW_CALLBACKS];
+
+extern "C" DM_DLLEXPORT bool DefoldImGui_RegisterDrawCallback(DefoldImGuiDrawCallback callback, void* user_data)
+{
+    if (!callback)
+    {
+        return false;
+    }
+
+    // Idempotent registration.
+    for (uint32_t i = 0; i < DEFOLD_IMGUI_MAX_DRAW_CALLBACKS; ++i)
+    {
+        if (g_DrawCallbacks[i].m_Callback == callback &&
+            g_DrawCallbacks[i].m_UserData == user_data)
+        {
+            return true;
+        }
+    }
+
+    for (uint32_t i = 0; i < DEFOLD_IMGUI_MAX_DRAW_CALLBACKS; ++i)
+    {
+        if (!g_DrawCallbacks[i].m_Callback)
+        {
+            g_DrawCallbacks[i].m_Callback = callback;
+            g_DrawCallbacks[i].m_UserData = user_data;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+extern "C" DM_DLLEXPORT void DefoldImGui_UnregisterDrawCallback(DefoldImGuiDrawCallback callback, void* user_data)
+{
+    for (uint32_t i = 0; i < DEFOLD_IMGUI_MAX_DRAW_CALLBACKS; ++i)
+    {
+        if (g_DrawCallbacks[i].m_Callback == callback &&
+            g_DrawCallbacks[i].m_UserData == user_data)
+        {
+            g_DrawCallbacks[i].m_Callback = 0;
+            g_DrawCallbacks[i].m_UserData = 0;
+        }
+    }
+}
+
+static void imgui_InvokeDrawCallbacks()
+{
+    // Iterate by index so callbacks may unregister themselves safely.
+    for (uint32_t i = 0; i < DEFOLD_IMGUI_MAX_DRAW_CALLBACKS; ++i)
+    {
+        DefoldImGuiDrawCallback callback = g_DrawCallbacks[i].m_Callback;
+        void* user_data = g_DrawCallbacks[i].m_UserData;
+        if (callback)
+        {
+            callback(user_data);
+        }
+    }
+}
+
+static void imgui_ClearDrawCallbacks()
+{
+    for (uint32_t i = 0; i < DEFOLD_IMGUI_MAX_DRAW_CALLBACKS; ++i)
+    {
+        g_DrawCallbacks[i].m_Callback = 0;
+        g_DrawCallbacks[i].m_UserData = 0;
+    }
+}
 
 
 static void imgui_ClearGLError()
@@ -3562,6 +3640,9 @@ static int imgui_GetFontSize(lua_State* L)
 static dmExtension::Result imgui_Draw(dmExtension::Params* params)
 {
     imgui_NewFrame();
+
+    imgui_InvokeDrawCallbacks();
+
     ImGui::Render();
 
     if (g_RenderingEnabled)
@@ -3797,6 +3878,8 @@ static void imgui_ExtensionInit()
 
 static void imgui_ExtensionShutdown()
 {
+    imgui_ClearDrawCallbacks();
+
     if (g_imgui_TextBuffer)
     {
         free(g_imgui_TextBuffer);
@@ -5935,6 +6018,15 @@ static void OnEventDefoldImGui(dmExtension::Params* params, const dmExtension::E
 }
 
 #else
+
+extern "C" DM_DLLEXPORT bool DefoldImGui_RegisterDrawCallback(DefoldImGuiDrawCallback callback, void* user_data)
+{
+    return false;
+}
+
+extern "C" DM_DLLEXPORT void DefoldImGui_UnregisterDrawCallback(DefoldImGuiDrawCallback callback, void* user_data)
+{
+}
 
 static dmExtension::Result AppInitializeDefoldImGui(dmExtension::AppParams* params)
 {


### PR DESCRIPTION
- Add public C API for native extensions to register/unregister ImGui draw callbacks
- Invoke registered callbacks after `ImGui::NewFrame()` and before `ImGui::Render()`
- Clear callbacks on extension shutdown